### PR TITLE
Update declaration of gettid to comply to glibc 2.30+

### DIFF
--- a/video.c
+++ b/video.c
@@ -539,7 +539,7 @@ static int X11HaveDPMS(xcb_connection_t *);
 static void X11DPMSReenable(xcb_connection_t *);
 static void X11DPMSDisable(xcb_connection_t *);
 #endif
-uint64_t gettid()
+uint64_t sys_gettid()
 {
 	return pthread_self();
 }

--- a/video.h
+++ b/video.h
@@ -254,9 +254,9 @@ extern int VideoRaiseWindow(void);
 extern void ActivateOsd(GLuint,int,int,int,int);
 #endif
 #if 0
-long int gettid()
+long int sys_gettid()
 {
-	return (long int)syscall(224);
+	return (long int)syscall(__NR_gettid);
 }
 #endif
 


### PR DESCRIPTION
Fix compiler error on distributions with current glibc