### PR TITLE
Code cleanup for newer ffmpeg versions

### DIFF
--- a/softhddev.c
+++ b/softhddev.c
@@ -44,19 +44,6 @@
 
 #include <libavcodec/avcodec.h>
 #include <libavutil/mem.h>
-// support old ffmpeg versions <1.0
-#if LIBAVCODEC_VERSION_INT < AV_VERSION_INT(55,18,102)
-#define AVCodecID CodecID
-#define AV_CODEC_ID_AAC CODEC_ID_AAC
-#define AV_CODEC_ID_AAC_LATM CODEC_ID_AAC_LATM
-#define AV_CODEC_ID_AC3 CODEC_ID_AC3
-#define AV_CODEC_ID_EAC3 CODEC_ID_EAC3
-#define AV_CODEC_ID_H264 CODEC_ID_H264
-#define AV_CODEC_ID_MP2 CODEC_ID_MP2
-#define AV_CODEC_ID_MPEG2VIDEO CODEC_ID_MPEG2VIDEO
-#define AV_CODEC_ID_NONE CODEC_ID_NONE
-#define AV_CODEC_ID_PCM_DVD CODEC_ID_PCM_DVD
-#endif
 
 #ifndef __USE_GNU
 #define __USE_GNU

--- a/video.h
+++ b/video.h
@@ -55,7 +55,6 @@ extern VideoHwDecoder *VideoNewHwDecoder(VideoStream *);
     /// Deallocate video hardware decoder.
 extern void VideoDelHwDecoder(VideoHwDecoder *);
 
-#ifdef LIBAVCODEC_VERSION
     /// Get and allocate a video hardware surface.
 extern unsigned VideoGetSurface(VideoHwDecoder *, const AVCodecContext *);
 
@@ -77,7 +76,6 @@ extern void *VideoGetHwAccelContext(VideoHwDecoder *);
     /// Draw vdpau render state.
 extern void VideoDrawRenderState(VideoHwDecoder *,
     struct vdpau_render_state *);
-#endif
 #endif
 
 #ifdef USE_OPENGLOSD


### PR DESCRIPTION
Drop ffmpeg compatibility checks
Set minimum ffmpeg API to 3.4
Set minimum VDR API to 2.4.0