### PR TITLE
Use pkg-config for most configuration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -159,6 +159,7 @@ endif
 
 ifeq ($(LIBPLACEBO_GL),1)
 CONFIG += -DPLACEBO_GL -DPLACEBO
+_CFLAGS += $(shell pkg-config --cflags libplacebo)
 LIBS += $(shell pkg-config --libs epoxy libplacebo)
 else
 LIBS += $(shell pkg-config --libs egl)
@@ -166,6 +167,7 @@ endif
 
 ifeq ($(LIBPLACEBO),1)
 CONFIG += -DPLACEBO
+_CFLAGS += $(shell pkg-config --cflags libplacebo)
 LIBS += $(shell pkg-config --libs egl libplacebo)
 endif
 

--- a/Makefile
+++ b/Makefile
@@ -159,29 +159,27 @@ endif
 
 ifeq ($(LIBPLACEBO_GL),1)
 CONFIG += -DPLACEBO_GL -DPLACEBO
-LIBS += -lepoxy
-LIBS += -lplacebo
+LIBS += $(shell pkg-config --libs epoxy libplacebo)
 else
-LIBS += -lEGL
+LIBS += $(shell pkg-config --libs egl)
 endif
 
 ifeq ($(LIBPLACEBO),1)
 CONFIG += -DPLACEBO
-LIBS += -lEGL
-LIBS += -lplacebo
+LIBS += $(shell pkg-config --libs egl libplacebo)
 endif
 
 ifeq ($(DRM),1)
 PLUGIN = softhddrm
 CONFIG += -DUSE_DRM -DVAAPI
 _CFLAGS += $(shell pkg-config --cflags libdrm)
-LIBS += -lgbm -ldrm -lEGL
+LIBS += $(shell pkg-config --libs egl gbm libdrm)
 endif
 
 ifeq ($(CUVID),1)
 #CONFIG += -DUSE_PIP			# PIP support
 CONFIG += -DCUVID			# enable CUVID decoder
-LIBS += -lEGL -lGL
+LIBS += $(shell pkg-config --libs egl gl)
 ifeq ($(YADIF),1)
 CONFIG += -DYADIF			# Yadif only with CUVID
 endif
@@ -273,7 +271,7 @@ ifeq ($(CUVID),1)
 LIBS += -lcuda -lnvcuvid
 endif
 
-LIBS += -lGLEW -lGLU  -ldl -lglut
+LIBS += -ldl $(shell pkg-config --libs glew glu glut)
 
 ### Includes and Defines (add further entries here):
 


### PR DESCRIPTION
This project does not strictly follow libplacebo stable releases but most distributions do, and those usually provide only single version. That could conflict with other applications like mpv, which distro links to stable version while softhdcuvid want's different one. Here comes pkg-config, which helps maintaining such configurations. When building softhdcuvid, simply alter PKG_CONFIG_PATH pointing to different libplacebo.pc file which stores all needed locations of headers and libraries. Thanks.