### PR TITLE
Fix HDR metadata frame lifetime, OSD scaling, ALSA recovery and DRM cleanup

### DIFF
--- a/audio.c
+++ b/audio.c
@@ -1132,9 +1132,10 @@ static int AlsaSetup(int *freq, int *channels, int passthrough) {
     int err;
     int delay;
 
-    if (!AlsaPCMHandle) { // alsa not running yet
-        // FIXME: if open fails for fe. pass-through, we never recover
-        return -1;
+    if (!AlsaPCMHandle) { // alsa not running yet - try to recover
+        if (!(AlsaPCMHandle = AlsaOpenPCM(passthrough))) {
+            return -1;
+        }
     }
     if (!AudioAlsaNoCloseOpen) { // close+open to fix HDMI no sound bug
         snd_pcm_t *handle;
@@ -1147,8 +1148,18 @@ static int AlsaSetup(int *freq, int *channels, int passthrough) {
         if (AudioAlsaCloseOpenDelay) {
             usleep(50 * 1000); // 50ms delay for alsa recovery
         }
-        // FIXME: can use multiple retries
-        if (!(handle = AlsaOpenPCM(passthrough))) {
+        // the device can be transiently busy right after close, so retry
+        {
+            int retry;
+
+            handle = NULL;
+            for (retry = 0; retry < 25 && !handle; retry++) {
+                if (!(handle = AlsaOpenPCM(passthrough))) {
+                    usleep(20 * 1000);
+                }
+            }
+        }
+        if (!handle) {
             return -1;
         }
         AlsaPCMHandle = handle;
@@ -1594,15 +1605,24 @@ static const AudioModule *AudioModules[] = {
 
 void AudioDelayms(int delayms) {
     int count;
+    int rest;
+    int framesize;
     unsigned char *p;
 
-#ifdef DEBUG
-    printf("Try Delay Audio for %d ms  Samplerate %d Channels %d bps %d\n", delayms,
-           AudioRing[AudioRingWrite].HwSampleRate, AudioRing[AudioRingWrite].HwChannels, AudioBytesProSample);
-#endif
+    framesize = AudioRing[AudioRingWrite].HwChannels * AudioBytesProSample;
 
     count = delayms * AudioRing[AudioRingWrite].HwSampleRate * AudioRing[AudioRingWrite].HwChannels *
             AudioBytesProSample / 1000;
+    // integer division above can leave a partial frame (e.g. 44100Hz/139ms
+    // -> 24519 bytes); that shifts the ring buffer write pointer permanently
+    rest = framesize ? count % framesize : 0;
+    count -= rest;
+
+#ifdef DEBUG
+    Error(_("audio: delay %d ms rate %d ch %d bps %d bytes %d rest %d\n"), delayms,
+          AudioRing[AudioRingWrite].HwSampleRate, AudioRing[AudioRingWrite].HwChannels, AudioBytesProSample, count,
+          rest);
+#endif
 
     if (delayms < 5000 && delayms > 0) { // not more than 5seconds
         p = calloc(1, count);
@@ -1686,10 +1706,11 @@ void AudioEnqueue(const void *samples, int count) {
 
     if (!AudioRunning) { // check, if we can start the thread
         int skip;
+        int framesize;
 
+        framesize = AudioRing[AudioRingWrite].HwChannels * AudioBytesProSample;
         n = RingBufferUsedBytes(AudioRing[AudioRingWrite].RingBuffer);
         skip = AudioSkip;
-        // FIXME: round to packet size
 
         Debug(4, "audio: start? %4zdms skip %dms\n",
               (n * 1000) / (AudioRing[AudioRingWrite].HwSampleRate * AudioRing[AudioRingWrite].HwChannels *
@@ -1701,7 +1722,14 @@ void AudioEnqueue(const void *samples, int count) {
             if (n < (unsigned)skip) {
                 skip = n;
             }
+            // never advance the read pointer by a partial frame
+            if (framesize) {
+                skip -= skip % framesize;
+            }
             AudioSkip -= skip;
+            if (AudioSkip < framesize) { // drop sub-frame residue
+                AudioSkip = 0;
+            }
             RingBufferReadAdvance(AudioRing[AudioRingWrite].RingBuffer, skip);
             n = RingBufferUsedBytes(AudioRing[AudioRingWrite].RingBuffer);
         }
@@ -1773,10 +1801,16 @@ void AudioVideoReady(int64_t pts) {
         if (skip > 0 && skip < 4000 * 90) {
             skip = (((int64_t)skip * AudioRing[AudioRingWrite].HwSampleRate) / (1000 * 90)) *
                    AudioRing[AudioRingWrite].HwChannels * AudioBytesProSample;
-            // FIXME: round to packet size
             if ((unsigned)skip > used) {
                 AudioSkip = skip - used;
                 skip = used;
+            }
+            { // never advance the read pointer by a partial frame
+                int framesize = AudioRing[AudioRingWrite].HwChannels * AudioBytesProSample;
+
+                if (framesize) {
+                    skip -= skip % framesize;
+                }
             }
             Debug(3, "audio: sync advance %dms %d/%zd  Rest %d\n",
                   (skip * 1000) / (AudioRing[AudioRingWrite].HwSampleRate * AudioRing[AudioRingWrite].HwChannels *

--- a/video.c
+++ b/video.c
@@ -688,8 +688,14 @@ static void VideoUpdateOutput(AVRational input_aspect_ratio, int input_width, in
 
     // input not initialized yet, return immediately
     if (!input_aspect_ratio.num || !input_aspect_ratio.den) {
+        Debug(3, "video: UpdateOutput early-return, SAR 0/0, stale crop was %dx%d\n",
+              *crop_width, *crop_height);
         *output_width = video_width;
         *output_height = video_height;
+        *crop_x = 0;
+        *crop_y = 0;
+        *crop_width = input_width;
+        *crop_height = input_height;
         return;
     }
 #ifdef USE_DRM
@@ -2959,11 +2965,15 @@ static enum AVPixelFormat Cuvid_get_format(CuvidDecoder *decoder, AVCodecContext
 
     Debug(3, "video profile %d codec id %d\n", video_ctx->profile, video_ctx->codec_id);
     if (*fmt_idx == AV_PIX_FMT_NONE) {
-        Fatal(_("video: no valid pixfmt found\n"));
+        Error(_("video: no valid pixfmt found (profile %d codec %d) - HW decode unavailable, aborting stream\n"),
+              video_ctx->profile, video_ctx->codec_id);
+        return AV_PIX_FMT_NONE;
     }
 
     if (*fmt_idx != PIXEL_FORMAT) {
-        Fatal(_("video: no valid profile found\n"));
+        Error(_("video: no valid profile found (profile %d codec %d)\n"),
+              video_ctx->profile, video_ctx->codec_id);
+        return AV_PIX_FMT_NONE;
     }
 
     //	  decoder->newchannel = 1;
@@ -3012,6 +3022,8 @@ static enum AVPixelFormat Cuvid_get_format(CuvidDecoder *decoder, AVCodecContext
             // dont show first frame
 #endif
         } else {
+            Debug(3, "GATE: SKIP reinit codec %dx%d InputW %dx%d\n",
+                  video_ctx->width, video_ctx->height, decoder->InputWidth, decoder->InputHeight);
             decoder->SyncCounter = 0;
             decoder->FrameCounter = 0;
             decoder->FramesDisplayed = 0;
@@ -3548,7 +3560,11 @@ static void CuvidRenderFrame(CuvidDecoder *decoder, const AVCodecContext *video_
     }
 
     if ((decoder->InputWidth != frame->width) || (decoder->InputHeight != frame->height)) {
-        //printf("Framesize change\n");
+        Debug(3, "RENDER framesize change InputW %d frame %d\n",
+              decoder->InputWidth, frame->width);
+#ifdef PLACEBO
+        VideoThreadLock();
+#endif
         CuvidCleanup(decoder);
         decoder->InputAspect = frame->sample_aspect_ratio;
         decoder->InputWidth = frame->width;
@@ -3556,6 +3572,9 @@ static void CuvidRenderFrame(CuvidDecoder *decoder, const AVCodecContext *video_
         decoder->Interlaced = 0;
         decoder->SurfacesNeeded = VIDEO_SURFACES_MAX + 1;
         CuvidSetupOutput(decoder);
+#ifdef PLACEBO
+        VideoThreadUnlock();
+#endif
     }
 
     // update aspect ratio changes
@@ -3888,14 +3907,17 @@ static void CuvidMixVideo(CuvidDecoder *decoder, __attribute__((unused)) int lev
     current = decoder->SurfacesRb[decoder->SurfaceRead];
 
 #ifdef USE_DRM
-    AVFrame *frame;
+    AVFrame *frame = NULL;
     AVFrameSideData *sd1 = NULL, *sd2 = NULL;
     if (!decoder->Closing) {
         frame = decoder->frames[current];
-        sd1 = av_frame_get_side_data(frame, AV_FRAME_DATA_MASTERING_DISPLAY_METADATA);
-        sd2 = av_frame_get_side_data(frame, AV_FRAME_DATA_CONTENT_LIGHT_LEVEL);
-
-        set_hdr_metadata(frame->color_primaries, frame->color_trc, sd1, sd2);
+        if (frame)
+            frame = av_frame_clone(frame); // Weg B: eigene refcounted Referenz, entkoppelt vom Slot
+        if (frame) {
+            sd1 = av_frame_get_side_data(frame, AV_FRAME_DATA_MASTERING_DISPLAY_METADATA);
+            sd2 = av_frame_get_side_data(frame, AV_FRAME_DATA_CONTENT_LIGHT_LEVEL);
+            set_hdr_metadata(frame->color_primaries, frame->color_trc, sd1, sd2);
+        }
     }
 #endif
 
@@ -4030,7 +4052,7 @@ static void CuvidMixVideo(CuvidDecoder *decoder, __attribute__((unused)) int lev
 
 #if USE_DRM
 
-    frame = decoder->frames[current];
+    // Weg B: frame ist bereits die geklonte Referenz von oben (nicht erneut roh aus dem Slot holen)
 
     switch (VulkanTargetColorSpace) {
         case 0: // Monitor
@@ -4040,7 +4062,8 @@ static void CuvidMixVideo(CuvidDecoder *decoder, __attribute__((unused)) int lev
             memcpy(&target->color, &pl_color_space_srgb, sizeof(struct pl_color_space));
             break;
         case 2: // HD TV
-            set_hdr_metadata(frame->color_primaries, frame->color_trc, sd1, sd2);
+            if (frame)
+                set_hdr_metadata(frame->color_primaries, frame->color_trc, sd1, sd2);
             if (decoder->ColorSpace == AVCOL_SPC_BT470BG) {
                 target->color.primaries = PL_COLOR_PRIM_BT_601_625;
                 target->color.transfer = PL_COLOR_TRC_BT_1886;
@@ -4049,7 +4072,8 @@ static void CuvidMixVideo(CuvidDecoder *decoder, __attribute__((unused)) int lev
             }
             break;
         case 3: // HDR TV
-            set_hdr_metadata(frame->color_primaries, frame->color_trc, sd1, sd2);
+            if (frame)
+                set_hdr_metadata(frame->color_primaries, frame->color_trc, sd1, sd2);
             if (decoder->ColorSpace == AVCOL_SPC_BT2020_NCL) {
                 memcpy(&target->color, &pl_color_space_bt2020_hlg, sizeof(struct pl_color_space));
             } else if (decoder->ColorSpace == AVCOL_SPC_BT470BG) {
@@ -4220,6 +4244,10 @@ static void CuvidMixVideo(CuvidDecoder *decoder, __attribute__((unused)) int lev
             Debug(3, "Failed rendering first frame!\n");
         }
         decoder->newchannel = 2;
+#ifdef USE_DRM
+        if (frame)
+            av_frame_free(&frame); // Weg B: Referenz freigeben (früher Austritt)
+#endif
         return;
     }
 
@@ -4272,6 +4300,10 @@ static void CuvidMixVideo(CuvidDecoder *decoder, __attribute__((unused)) int lev
         pl_renderer_destroy(&p->renderertest);
         p->renderertest = NULL;
     }
+#endif
+#ifdef USE_DRM
+    if (frame)
+        av_frame_free(&frame); // Weg B: Referenz freigeben (regulärer Austritt)
 #endif
 }
 
@@ -4345,35 +4377,57 @@ void make_osd_overlay(int x, int y, int width, int height) {
     pl->repr.alpha = PL_ALPHA_INDEPENDENT;
 
     memcpy(&osdoverlay.color, &pl_color_space_srgb, sizeof(struct pl_color_space));
+
+    // the OSD is rendered at OsdWidth x OsdHeight, the window can be larger
+    // (e.g. 1080p OSD on a 2160p screen). Keep the texture at OSD size and
+    // scale only the destination rect, so the GPU does the upscaling.
+    {
+        int dx0, dx1, dy0, dy1;
+
+        if (OsdWidth > 0 && OsdHeight > 0) {
+            dx0 = (x * (int)VideoWindowWidth) / OsdWidth;
+            dx1 = ((x + width) * (int)VideoWindowWidth) / OsdWidth;
+            dy0 = (y * (int)VideoWindowHeight) / OsdHeight;
+            dy1 = ((y + height) * (int)VideoWindowHeight) / OsdHeight;
+        } else {
+            dx0 = x;
+            dx1 = x + width;
+            dy0 = y;
+            dy1 = y + height;
+        }
+
 #if PL_API_VER < 229
 #ifdef PLACEBO_GL
-    pl->rect.x0 = x;
-    pl->rect.y1 = VideoWindowHeight - y; // Boden von oben
-    pl->rect.x1 = x + width;
-    pl->rect.y0 = VideoWindowHeight - height - y;
+        pl->rect.x0 = dx0;
+        pl->rect.y1 = VideoWindowHeight - dy0; // Boden von oben
+        pl->rect.x1 = dx1;
+        pl->rect.y0 = VideoWindowHeight - dy1;
 #else
-    int offset = VideoWindowHeight - (VideoWindowHeight - height - y) - (VideoWindowHeight - y);
-    pl->rect.x0 = x;
-    pl->rect.y0 = VideoWindowHeight - y + offset; // Boden von oben
-    pl->rect.x1 = x + width;
-    pl->rect.y1 = VideoWindowHeight - height - y + offset;
+        int offset = VideoWindowHeight - (VideoWindowHeight - dy1) - (VideoWindowHeight - dy0);
+
+        pl->rect.x0 = dx0;
+        pl->rect.y0 = VideoWindowHeight - dy0 + offset; // Boden von oben
+        pl->rect.x1 = dx1;
+        pl->rect.y1 = VideoWindowHeight - dy1 + offset;
 #endif
 #else
-    osdoverlay.parts = &part;
-    osdoverlay.num_parts = 1;
+        osdoverlay.parts = &part;
+        osdoverlay.num_parts = 1;
 #ifdef PLACEBO_GL
-    part.dst.x0 = x;
-    part.dst.y1 = VideoWindowHeight - y; // Boden von oben
-    part.dst.x1 = x + width;
-    part.dst.y0 = VideoWindowHeight - height - y;
+        part.dst.x0 = dx0;
+        part.dst.y1 = VideoWindowHeight - dy0; // Boden von oben
+        part.dst.x1 = dx1;
+        part.dst.y0 = VideoWindowHeight - dy1;
 #else
-    int offset = VideoWindowHeight - (VideoWindowHeight - height - y) - (VideoWindowHeight - y);
-    part.dst.x0 = x;
-    part.dst.y0 = VideoWindowHeight - y + offset; // Boden von oben
-    part.dst.x1 = x + width;
-    part.dst.y1 = VideoWindowHeight - height - y + offset;
+        int offset = VideoWindowHeight - (VideoWindowHeight - dy1) - (VideoWindowHeight - dy0);
+
+        part.dst.x0 = dx0;
+        part.dst.y0 = VideoWindowHeight - dy0 + offset; // Boden von oben
+        part.dst.x1 = dx1;
+        part.dst.y1 = VideoWindowHeight - dy1 + offset;
 #endif
 #endif
+    }
 }
 #endif
 ///
@@ -7339,6 +7393,9 @@ void VideoExit(void) {
     VideoThreadExit(); // destroy all mutexes
 #endif
 
+#ifdef USE_DRM
+    drm_clean_up();     // drmDropMaster + close(fd) -> gibt card1 frei
+#endif
 #ifdef USE_GLX
     if (EglEnabled) {
         EglExit(); // delete all contexts


### PR DESCRIPTION
This PR collects several fixes found while running the `softhddrm` build (`DRM=1`, `LIBPLACEBO_GL=1`) with HDR output. All of them apply cleanly on current `master` (790a8d7).

### video.c

**1. `CuvidMixVideo()`: use a refcounted reference for HDR metadata (USE_DRM)**

The DRM path read `decoder->frames[current]` directly and kept using that raw pointer down to the `VulkanTargetColorSpace` switch, where `set_hdr_metadata()` is called again with `frame->color_primaries` and the side data pointers. The surface slot can be recycled in between, so the side data (`MASTERING_DISPLAY_METADATA`, `CONTENT_LIGHT_LEVEL`) may already be gone by then. This now takes an `av_frame_clone()` reference at the top and frees it on both exit paths, plus NULL guards. This was the concrete cause of unstable HDR metadata on channel switches here.

**2. `Cuvid_get_format()`: return `AV_PIX_FMT_NONE` instead of `Fatal()`**

A stream the hardware cannot decode currently terminates the whole VDR process. `AV_PIX_FMT_NONE` is the documented way for a `get_format` callback to decline -- see `ff_get_format()` in `libavcodec/decode.c`:

```c
user_choice = avctx->get_format(avctx, choices);
if (user_choice == AV_PIX_FMT_NONE) {
    // Explicitly chose nothing, give up.
    ret = AV_PIX_FMT_NONE;
    break;
}
```

`ff_hwaccel_uninit()` runs before the break, and the decoders propagate the negative return normally (e.g. `h264_slice.c:1161`). So the stream fails, the process survives. The messages were changed from `Fatal()` to `Error()` and now include profile and codec id.

**3. `make_osd_overlay()`: scale the destination rect from OSD size to window size**

The OSD is rendered at `OsdWidth`x`OsdHeight`, which need not match the output window (1080p OSD on a 2160p screen). The destination rect was built from raw OSD coordinates, so the OSD ended up in a corner. The texture stays at OSD size and only the destination rect is scaled, leaving the upscaling to the GPU. Handles both `PL_API_VER < 229` and the `parts`/`num_parts` path, GL and non-GL.

**4. `CuvidRenderFrame()`: lock around cleanup on frame size change**

`CuvidCleanup()` + `CuvidSetupOutput()` on a resolution change ran unsynchronised against the render thread. Wrapped in `VideoThreadLock()`/`VideoThreadUnlock()` under `PLACEBO`.

**5. `VideoUpdateOutput()`: reset crop on the early return**

When the input SAR is still 0/0 the function returns early but left `crop_x/y/width/height` at their previous values, so a stale crop from the last stream was applied. They are now reset to the full input rect.

**6. `VideoExit()`: call `drm_clean_up()`**

Without `drmDropMaster()` + `close(fd)` the card stays claimed after VDR exits, which breaks handing the output over to another application.

### audio.c

**7. `AlsaSetup()`: recover when no PCM handle is open**

Replaces the `FIXME: if open fails for fe. pass-through, we never recover` -- it now tries `AlsaOpenPCM()` instead of returning -1 unconditionally.

**8. `AlsaSetup()`: retry the reopen after close**

Replaces `FIXME: can use multiple retries`. The device can be transiently busy right after close; up to 25 attempts, 20 ms apart.

**9. `AudioDelayms()`: round the byte count down to whole frames**

The integer division can leave a partial frame (44100 Hz / 139 ms -> 24519 bytes with a 4-byte frame). That misaligns the ring buffer write pointer permanently, and every following sample is off by the residue.

**10. `AudioEnqueue()` / `AudioVideoReady()`: round `skip` down to frame size**

Same class of bug on the read side -- this is the `FIXME: round to packet size` in both places. The sub-frame residue in `AudioSkip` is dropped rather than carried forward.

### Testing

- Hardware: Intel Arc A310 (DG2, i915), output via HDMI to a Pioneer VSX-1131
  receiver at 3840x2160, HDR10 and HLG sources
- Build: `DRM=1`, `LIBPLACEBO_GL=1`, libplacebo 7.349.0, FFmpeg 6.1
  (libavcodec 60.31.102 / libavutil 58.29.100), Mesa 25.2.8, kernel
  6.8.0-136-generic (Ubuntu 24.04)
- Running in daily use since 2026-07-21 including channel switches between SDR/HDR and between resolutions, recordings playback, fast forward/rewind
  